### PR TITLE
Refactoring of printout/logging messages, mainly to make "authorize_privileges" flag appear.

### DIFF
--- a/fuzzer/cascade/fuzzfromdescriptor.py
+++ b/fuzzer/cascade/fuzzfromdescriptor.py
@@ -83,16 +83,16 @@ def fuzz_single_from_descriptor(memsize: int, design_name: str, randseed: int, n
     try:
         gathered_times = run_rtl(memsize, design_name, randseed, nmax_bbs, authorize_privileges, check_pc_spike_again)
         if loggers is not None:
-            loggers[random.randrange(len(loggers))].log(True, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs}, False, '') # No message for successful runs
+            loggers[random.randrange(len(loggers))].log(True, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs, 'authorize_privileges': authorize_privileges}, False, '') # No message for successful runs
         else:
             return gathered_times
     except Exception as e:
         if loggers is not None:
             emsg = str(e)
             if 'Spike timeout' in emsg:
-                loggers[random.randrange(len(loggers))].log(False, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs}, True, '') # No message for Spike timeouts
+                loggers[random.randrange(len(loggers))].log(False, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs, 'authorize_privileges': authorize_privileges}, True, '') # No message for Spike timeouts
             else:
-                loggers[random.randrange(len(loggers))].log(False, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs}, False, emsg)
+                loggers[random.randrange(len(loggers))].log(False, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs, 'authorize_privileges': authorize_privileges}, False, emsg)
         else:
-            print(f"Failed test_run_rtl_single for params memsize: `{memsize}`, design_name: `{design_name}`, check_pc_spike_again: `{check_pc_spike_again}`, randseed: `{randseed}`, nmax_bbs: `{nmax_bbs}` -- ({memsize}, design_name, {randseed}, {nmax_bbs})\n{e}")
+            print(f"Failed test_run_rtl_single for params memsize: `{memsize}`, design_name: `{design_name}`, check_pc_spike_again: `{check_pc_spike_again}`, randseed: `{randseed}`, nmax_bbs: `{nmax_bbs}`, authorize_privileges: `{authorize_privileges}` -- ({memsize}, design_name, {randseed}, {nmax_bbs}, {authorize_privileges})\n{e}")
         return 0, 0, 0, 0

--- a/fuzzer/cascade/fuzzsim.py
+++ b/fuzzer/cascade/fuzzsim.py
@@ -169,11 +169,11 @@ def runtest_simulator(fuzzerstate, elfpath: str, expected_regvals: tuple, overri
 
     # Check successful stop
     if not is_stop_successful:
-        return False, f"Timeout for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, randseed: `{fuzzerstate.randseed}` -- ({fuzzerstate.memsize}, design_name, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs})"
+        return False, f"Timeout for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, randseed: `{fuzzerstate.randseed}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, authorize_privileges: `{fuzzerstate.authorize_privileges}` -- ({fuzzerstate.memsize}, {fuzzerstate.design_name}, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}, {fuzzerstate.authorize_privileges})"
 
     # Check that we retrieved the regs correctly
     if received_regvals is None:
-        raise Exception(f"Missing all regs for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, randseed: `{fuzzerstate.randseed}`")
+        raise Exception(f"Missing all regs for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, randseed: `{fuzzerstate.randseed}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, authorize_privileges: `{fuzzerstate.authorize_privileges}` -- ({fuzzerstate.memsize}, {fuzzerstate.design_name}, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}, {fuzzerstate.authorize_privileges})")
 
     received_intregvals, received_floatregvals = received_regvals
     del received_regvals
@@ -189,14 +189,14 @@ def runtest_simulator(fuzzerstate, elfpath: str, expected_regvals: tuple, overri
     for reg_id in range(fuzzerstate.num_pickable_regs-1):
         if expected_intregvals[reg_id] != received_intregvals[reg_id] and fuzzerstate.intregpickstate.get_regstate(reg_id+1) in (IntRegIndivState.FREE, IntRegIndivState.CONSUMED):
             reg_mismatch = True
-            ret_str_list_regmismatch.append(f"Register mismatch (x{reg_id+1}) for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, randseed: `{fuzzerstate.randseed}`. State: {fuzzerstate.intregpickstate.get_regstate(reg_id+1)}. Expected `{hex(expected_intregvals[reg_id])}`, got `{hex(received_intregvals[reg_id])}`.")
+            ret_str_list_regmismatch.append(f"Register mismatch (x{reg_id+1}) for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, randseed: `{fuzzerstate.randseed}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, authorize_privileges: `{fuzzerstate.authorize_privileges}`. State: {fuzzerstate.intregpickstate.get_regstate(reg_id+1)}. Expected `{hex(expected_intregvals[reg_id])}`, got `{hex(received_intregvals[reg_id])}`.")
 
     if fuzzerstate.design_has_fpu:
         for fp_reg_id in range(fuzzerstate.num_pickable_floating_regs):
             # received_floatregvals[fp_reg_id] can be None if the FPU is disabled in the final block and the final permission level does not permit enabling it.
             if expected_floatregvals[fp_reg_id] != received_floatregvals[fp_reg_id] and received_floatregvals[fp_reg_id] is not None:
                 reg_mismatch = True
-                ret_str_list_regmismatch.append(f"Register mismatch (f{fp_reg_id}) for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, randseed: `{fuzzerstate.randseed}`. Expected `{hex(expected_floatregvals[fp_reg_id])}`, got `{hex(received_floatregvals[fp_reg_id])}`.")
+                ret_str_list_regmismatch.append(f"Register mismatch (f{fp_reg_id}) for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, randseed: `{fuzzerstate.randseed}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, authorize_privileges: `{fuzzerstate.authorize_privileges}`. Expected `{hex(expected_floatregvals[fp_reg_id])}`, got `{hex(received_floatregvals[fp_reg_id])}`.")
     return not reg_mismatch, '\n  '.join(ret_str_list_regmismatch)
 
 
@@ -207,7 +207,7 @@ def runtest_modelsim(fuzzerstate, elfpath: str, coveragepath: str):
     is_stop_successful, _ = runsim_modelsim(fuzzerstate.design_name, num_instrs*MAX_CYCLES_PER_INSTR + SETUP_CYCLES, elfpath, 1, 0, coveragepath)
     # Check successful stop
     if not is_stop_successful:
-        raise Exception(f"Timeout during modelsim testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, design_name, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}).")
+        raise Exception(f"Timeout during modelsim testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, {fuzzerstate.design_name}, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}, {fuzzerstate.authorize_privileges}).")
 
 # Runs the test and checks for a single dumped register.
 # @return the value of the dumped register
@@ -220,7 +220,7 @@ def runtest_verilator_forprofiling(fuzzerstate, elfpath: str, expected_fuzzersta
         raise Exception(f"Timeout during profiling of design `{fuzzerstate.design_name}`.")
     # Check that we retrieved the regs correctly
     if received_regvals is None:
-        raise Exception(f"Missing all regs for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, randseed: `{fuzzerstate.randseed}`")
+        raise Exception(f"Missing all regs for params: memsize: `{fuzzerstate.memsize}`, design_name: `{fuzzerstate.design_name}`, randseed: `{fuzzerstate.randseed}`, nmax_bbs: `{fuzzerstate.nmax_bbs}`, authorize_privileges: `{fuzzerstate.authorize_privileges}`")
     received_intregvals, received_floatregvals = received_regvals
     del received_regvals
     if DO_ASSERT:
@@ -235,7 +235,7 @@ def runtest_verilator_forrfuzz(fuzzerstate, elfpath: str):
     is_stop_successful, rfuzz_coverage_mask = runsim_verilator(fuzzerstate.design_name, num_instrs*MAX_CYCLES_PER_INSTR + SETUP_CYCLES, elfpath, 1, 0, get_rfuzz_coverage_mask=True)
     # Check successful stop
     if not is_stop_successful:
-        raise Exception(f"Timeout during rfuzz coverage testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, design_name, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}).")
+        raise Exception(f"Timeout during rfuzz coverage testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, {fuzzerstate.design_name}, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}, {fuzzerstate.authorize_privileges}).")
     return rfuzz_coverage_mask
 
 # Runs the test in the goal of collecting modelsim coverage.
@@ -245,4 +245,4 @@ def runtest_modelsim_forcoverage(fuzzerstate, elfpath: str, coveragepath: str):
     is_stop_successful, _ = runsim_modelsim(fuzzerstate.design_name, num_instrs*MAX_CYCLES_PER_INSTR + SETUP_CYCLES, elfpath, 1, 0, coveragepath)
     # Check successful stop
     if not is_stop_successful:
-        raise Exception(f"Timeout during modelsim testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, design_name, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}).")
+        raise Exception(f"Timeout during modelsim testing of design `{fuzzerstate.design_name}` for tuple ({fuzzerstate.memsize}, {fuzzerstate.design_name}, {fuzzerstate.randseed}, {fuzzerstate.nmax_bbs}, {fuzzerstate.authorize_privileges}).")

--- a/fuzzer/cascade/reduce.py
+++ b/fuzzer/cascade/reduce.py
@@ -688,7 +688,7 @@ def reduce_program(memsize: int, design_name: str, randseed: int, nmax_bbs: int,
     # If no fail at all
     if failing_bb_id == len(fuzzerstate.instr_objs_seq) and not is_mismatch(fuzzerstate, failing_bb_id-1):
         if not quiet:
-            print(f"Success (no failure at all with tuple: ({memsize}, design_name, {randseed}, {nmax_bbs})")
+            print(f"Success (no failure at all with tuple: ({memsize}, {design_name}, {randseed}, {nmax_bbs}, {authorize_privileges}))")
         return True, time.time() - start_time, numinstrs
 
     ###


### PR DESCRIPTION
Refactoring of printout/logging messages, making "authorize_privileges" flag appear in output messages of "do_reducesingle.py", "do_fuzzsingle.py" and "do_fuzzdesign.py".

Changes are as follows:
  - "authorize_privileges" flag also appearing, helpful for parsing output info of "do_fuzzdesign.py"
  - Consistent format of descriptor info, always in the following order: memsize, design_name, randseed, nmax_bbs, authorize_privileges
  - Some printout/logging messages didn't have "design_name" between "{}" for string formatting