### PR TITLE
Missed string formatting fix for verbose printout and ISA extension correction

### DIFF
--- a/fuzzer/cascade/fuzzfromdescriptor.py
+++ b/fuzzer/cascade/fuzzfromdescriptor.py
@@ -94,5 +94,5 @@ def fuzz_single_from_descriptor(memsize: int, design_name: str, randseed: int, n
             else:
                 loggers[random.randrange(len(loggers))].log(False, {'memsize': memsize, 'design_name': design_name, 'randseed': randseed, 'nmax_bbs': nmax_bbs, 'authorize_privileges': authorize_privileges}, False, emsg)
         else:
-            print(f"Failed test_run_rtl_single for params memsize: `{memsize}`, design_name: `{design_name}`, check_pc_spike_again: `{check_pc_spike_again}`, randseed: `{randseed}`, nmax_bbs: `{nmax_bbs}`, authorize_privileges: `{authorize_privileges}` -- ({memsize}, design_name, {randseed}, {nmax_bbs}, {authorize_privileges})\n{e}")
+            print(f"Failed test_run_rtl_single for params memsize: `{memsize}`, design_name: `{design_name}`, check_pc_spike_again: `{check_pc_spike_again}`, randseed: `{randseed}`, nmax_bbs: `{nmax_bbs}`, authorize_privileges: `{authorize_privileges}` -- ({memsize}, {design_name}, {randseed}, {nmax_bbs}, {authorize_privileges})\n{e}")
         return 0, 0, 0, 0

--- a/fuzzer/common/designcfgs.py
+++ b/fuzzer/common/designcfgs.py
@@ -88,7 +88,7 @@ def design_has_float_support(design_name) -> bool:
 
 @cache
 def design_has_double_support(design_name) -> bool:
-    return 'f' in get_design_march_flags(design_name) or 'g' in get_design_march_flags(design_name)
+    return 'd' in get_design_march_flags(design_name) or 'g' in get_design_march_flags(design_name)
 
 @cache
 def design_has_muldiv_support(design_name) -> bool:


### PR DESCRIPTION
Missed string formatting fix for more verbose printout info.

Also, design_has_double_support() function had the ISA extension char incorrectly set to 'f' instead of 'd'.