### PR TITLE
Small fixes to fpoint stores 32/64 bit and Python unpacking

### DIFF
--- a/fuzzer/cascade/finalblock.py
+++ b/fuzzer/cascade/finalblock.py
@@ -6,7 +6,7 @@
 
 from params.runparams import DO_ASSERT
 from rv.csrids import CSR_IDS
-from common.designcfgs import is_design_32bit, get_design_stop_sig_addr, get_design_reg_dump_addr, design_has_float_support, get_design_fpreg_dump_addr
+from common.designcfgs import is_design_32bit, get_design_stop_sig_addr, get_design_reg_dump_addr, design_has_float_support, design_has_double_support, get_design_fpreg_dump_addr
 from params.fuzzparams import RDEP_MASK_REGISTER_ID, MAX_NUM_PICKABLE_REGS, MAX_NUM_PICKABLE_FLOATING_REGS, FPU_ENDIS_REGISTER_ID
 from cascade.privilegestate import PrivilegeStateEnum
 from rv.asmutil import li_into_reg
@@ -34,7 +34,7 @@ def finalblock(fuzzerstate, design_name: str):
     ret = []
     is_design_64bit = not is_design_32bit(design_name)
     design_has_fpu = design_has_float_support(design_name)
-    design_has_fpud = design_has_float_support(design_name)
+    design_has_fpudouble = design_has_double_support(design_name)
 
     ###
     # Dump registers
@@ -66,7 +66,7 @@ def finalblock(fuzzerstate, design_name: str):
             fuzzerstate.is_fpu_activated = True
         if fuzzerstate.is_fpu_activated:
             for reg_id in range(MAX_NUM_PICKABLE_FLOATING_REGS):
-                ret.append(FloatStoreInstruction("fsd" if design_has_fpud else "fsw", RDEP_MASK_REGISTER_ID, reg_id, 8, -1, is_design_64bit))
+                ret.append(FloatStoreInstruction("fsd" if design_has_fpudouble else "fsw", RDEP_MASK_REGISTER_ID, reg_id, 8, -1, is_design_64bit))
                 ret.append(SpecialInstruction("fence"))
 
     ###

--- a/fuzzer/cascade/reduce.py
+++ b/fuzzer/cascade/reduce.py
@@ -822,7 +822,7 @@ def reduce_program(memsize: int, design_name: str, randseed: int, nmax_bbs: int,
     if failing_instr_id == -1 and fault_from_prev_bb:
         ret = gen_reduced_elf(fuzzerstate, failing_bb_id-1)
         if ret is False:
-            test_fuzzerstate_smaller, rtl_elfpath_smaller, expected_regvals_pairs_smaller, numinstrs_smaller = itertools.repeat(None)
+            test_fuzzerstate_smaller, rtl_elfpath_smaller, expected_regvals_pairs_smaller, numinstrs_smaller = itertools.repeat(None, 4)
             print('Warning: smaller is trivial. Error may come from initial block.')
             return True, time.time() - start_time, numinstrs
         else:


### PR DESCRIPTION
- "design_has_fpud" flag to determine whether to add "fsd" or "fsw" to the last basic block was getting its value from "design_has_float_support()" instead of "design_has_double_support()"
- Small unpacking error, "itertools.repeat(None)" must have an integer with the number of variables on the left side of the assignment