### PR TITLE
Bug fixes

### DIFF
--- a/design-processing/common/python_scripts/divide_concat_into_subconcats.py
+++ b/design-processing/common/python_scripts/divide_concat_into_subconcats.py
@@ -54,7 +54,7 @@ def reduce_bracket(match):
     if is_there_remainder:
         ret_groups.append("  {} [{}-1:0] {}_{};".format(TYPE, tot_num_elems % MAX_TERMS_IN_BRACKET, var_name_with_suffix, num_macroterms_floor))
 
-    ret_groups.append("  assign {} = {}_0;".format(var_name, var_name_with_suffix))
+    ret_groups.append("  assign {} = {{ {} }};".format(var_name, ', '.join([f'{var_name_with_suffix}_{i}' for i in range(num_macroterms_floor + 1 if is_there_remainder  else num_macroterms_floor)])))
 
     for macroterm_id in range(num_macroterms_floor):
         macrobracket_content = ' , '.join(splitted[macroterm_id*MAX_TERMS_IN_BRACKET:(macroterm_id+1)*MAX_TERMS_IN_BRACKET])

--- a/fuzzer/cascade/randomize/pickisainstrclass.py
+++ b/fuzzer/cascade/randomize/pickisainstrclass.py
@@ -52,9 +52,8 @@ ISAINSTRCLASS_INITIAL_BOOSTERS = {
 # return a ISAInstrClass
 # Do NOT @cache this function, as it is a random function.
 def _gen_next_isainstrclass_from_weights(weights: list = None) -> ISAInstrClass:
-    ret = None
-    while ret is None or weights[ret] == 0:
-        ret = random.choices(list(ISAInstrClass), weights=weights)[0]
+    ret = random.choices(list(weights.keys()), weights=weights.values())[0]
+    assert weights[ret] != 0
     return ret
 
 # @brief For now, the weights used for choosing instructions are fixed over time.


### PR DESCRIPTION
A few bug fixes:
- 64742ed47fe9974c2b6d8d506209573062801ad3: Fixes the macro term expansion.
- a6cf3e9ec92a451be43458468319b88e5b27f853: Fixes the MINSTRET initialisation for RV32 and the computation of the starting address of the random register values stored in memory.
- 19241c68c8079857613cd2baebdabd19756ddc03: Fixes the _gen_next_isainstrclass_from_weights function s.t. the derived non-zero weights are also used.