### PR TITLE
Misaligned load/store do not require FPU.

### DIFF
--- a/fuzzer/cascade/cfinstructionclasses.py
+++ b/fuzzer/cascade/cfinstructionclasses.py
@@ -1161,16 +1161,12 @@ class MisalignedMemInstruction(ExceptionInstruction):
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_LWU:
             self.meminstr = IntLoadInstruction("lwu", random_reg, rs1, imm, self.producer_id, fuzzerstate.is_design_64bit, iscompressed)
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_LD:
-            if DO_ASSERT:
-                assert fuzzerstate.design_has_fpu
             self.meminstr = IntLoadInstruction("ld", random_reg, rs1, imm, self.producer_id, fuzzerstate.is_design_64bit, iscompressed)
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_SH:
             self.meminstr = IntStoreInstruction("sh", rs1, random_reg, imm, self.producer_id, fuzzerstate.is_design_64bit, iscompressed)
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_SW:
             self.meminstr = IntStoreInstruction("sw", rs1, random_reg, imm, self.producer_id, fuzzerstate.is_design_64bit, iscompressed)
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_SD:
-            if DO_ASSERT:
-                assert fuzzerstate.design_has_fpu
             self.meminstr = IntStoreInstruction("sd", rs1, random_reg, imm, self.producer_id, fuzzerstate.is_design_64bit, iscompressed)
         elif meminstr_type == MisalignedMemInstruction.MISALIGNED_FLW:
             if DO_ASSERT:


### PR DESCRIPTION
ld/sd do not need FPU, even if misaligned.
Remove incorrect asserts.